### PR TITLE
Update examples/tutorials/mnist/mnist_softmax.py

### DIFF
--- a/tensorflow/examples/tutorials/mnist/mnist_softmax.py
+++ b/tensorflow/examples/tutorials/mnist/mnist_softmax.py
@@ -46,7 +46,7 @@ def main(_):
 
   # The raw formulation of cross-entropy,
   #
-  #   tf.reduce_mean(-tf.reduce_sum(y_ * tf.log(tf.softmax(y)),
+  #   tf.reduce_mean(-tf.reduce_sum(tf.softmax(y) * tf.log(y_),
   #                                 reduction_indices=[1]))
   #
   # can be numerically unstable.


### PR DESCRIPTION
The comment is wrong. tf.softmax(y) is predicted probability distribution while y_ is the label. Check more about cross-entropy(http://colah.github.io/posts/2015-09-Visual-Information/#cross-entropy)